### PR TITLE
YSHOP2-508: Collections cover image should be object-fit cover to the image.

### DIFF
--- a/assets/collection-listing.css
+++ b/assets/collection-listing.css
@@ -51,6 +51,7 @@
   height: 100%;
   flex: 1;
   transition: all 0.25s ease;
+  object-fit: cover;
 }
 .yc-collection-listing .collection-list .collection-thumbnail:hover img {
   transform: scale(1.1);

--- a/styles/collection-listing.scss
+++ b/styles/collection-listing.scss
@@ -47,6 +47,7 @@
         height: 100%;
         flex: 1;
         transition: all 0.25s ease;
+        object-fit: cover;
       }
 
       &:hover img {


### PR DESCRIPTION
## JIRA Ticket

[YSHOP2-508](https://youcanshop.atlassian.net/browse/YSHOP2-X508

## QA Steps

-  [ ] `pnpm i`
-  [ ] `pnpm dev`
-  [ ] Go to collections page
-  [ ] Images should not be stretched

## Note

Leave empty when you have nothing to say


[YSHOP2-508]: https://youcanshop.atlassian.net/browse/YSHOP2-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ