### PR TITLE
DARK : theme 3 > fix product image size

### DIFF
--- a/assets/product.css
+++ b/assets/product.css
@@ -29,6 +29,7 @@
   .yc-single-product .product-images {
     position: sticky;
     top: calc(var(--yc-nav-height) + 30px);
+    width: 50%;
   }
 }
 .yc-single-product .product-images .splide {
@@ -116,6 +117,11 @@
   width: 100%;
   display: flex;
   flex-direction: column;
+}
+@media (min-width: 768px) {
+  .yc-single-product .product-details {
+    width: 50%;
+  }
 }
 .yc-single-product .product-details .product-name {
   display: none;

--- a/styles/product.scss
+++ b/styles/product.scss
@@ -32,6 +32,7 @@
     @include breakpoint('md') {
       position: sticky;
       top: calc(var(--yc-nav-height) + 30px);
+      width: 50%;
     }
 
     .splide {
@@ -130,6 +131,10 @@
     width: 100%;
     display: flex;
     flex-direction: column;
+
+    @include breakpoint('md') {
+      width: 50%;
+    }
 
     .product-name {
       display: none;


### PR DESCRIPTION
## Issue

The image in the product page turns small when the description content is huge
<img width="1337" alt="Screen Shot 2023-07-28 at 12 28 29" src="https://github.com/youcan-shop/cod-theme-3/assets/93322743/9728251a-0ca5-4062-842b-18315a96c7ac">


## QA Steps

-  [ ] `pnpm i`
-  [ ] `pnpm dev`
