### PR TITLE
DARK: theme 3 > collection page > fix the display of product link button

### DIFF
--- a/assets/product-listing.css
+++ b/assets/product-listing.css
@@ -38,9 +38,9 @@
   }
 }
 .yc-product-listing-container .product-list .product-block .product-thumbnail .product-link {
+  display: none;
   width: 78%;
   margin: auto;
-  display: block;
   top: 120%;
   transition: all 0.25s;
 }
@@ -50,6 +50,7 @@
 }
 @media (min-width: 768px) {
   .yc-product-listing-container .product-list .product-block .product-thumbnail .product-link {
+    display: block;
     width: 80%;
     position: absolute;
     z-index: 1;

--- a/styles/product-listing.scss
+++ b/styles/product-listing.scss
@@ -41,9 +41,9 @@
         }
 
         .product-link {
+          display: none;
           width: 78%;
           margin: auto;
-          display: block;
           top: 120%;
           transition: all 0.25s;
 
@@ -53,6 +53,7 @@
           }
 
           @include breakpoint('md') {
+            display: block;
             width: 80%;
             position: absolute;
             z-index: 1;


### PR DESCRIPTION
## JIRA Ticket

## Issue
The display of two product link buttons in mobile vesion
<img width="615" alt="Screen Shot 2023-10-16 at 16 16 42" src="https://github.com/youcan-shop/cod-theme-3/assets/93322743/f3d0c95f-593d-4d35-9b96-11b111c51f88">


## QA Steps

-  [ ] `pnpm i`
-  [ ] `pnpm dev`
-  [ ] Go to collection page and choose your collection
-  [ ] Resize the screen and check if the products has only 1 button 

## Note

Leave empty when you have nothing to say
