### PR TITLE
Dark: fix empty page height

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -21,6 +21,11 @@ body {
   position: relative;
 }
 
+.main-content {
+  display: inline-block;
+  width: 100%;
+}
+
 .yc-btn span,
 .yc-btn,
 html,

--- a/assets/main.js
+++ b/assets/main.js
@@ -237,21 +237,23 @@ function desktopStickyElements(elementsContainer) {
  */
 
 function stickFooterAtBottom() {
-  const stickFooter = $('#stick-footer');
+  const mainContent = $('.main-content');
   let htmlPageHeight = document.documentElement.clientHeight;
   let bodyHeight = document.body.offsetHeight;
   let emptySpaceHeight = `${htmlPageHeight - bodyHeight}px`;
 
   if (emptySpaceHeight < '0px') {
-    emptySpaceHeight = '32px';
+    emptySpaceHeight = '0px';
   }
 
-  if (stickFooter) {
-    stickFooter.style.marginBottom = emptySpaceHeight;
+  if (mainContent) {
+    mainContent.style.marginBottom = emptySpaceHeight;
   }
 }
 
-stickFooterAtBottom();
+window.addEventListener('load', (event) => {
+  stickFooterAtBottom();
+});
 
 /* ------------------------------------------------------ */
 /* ----- Display each video section -------------------- */

--- a/layouts/theme.liquid
+++ b/layouts/theme.liquid
@@ -18,7 +18,9 @@
     {%- section 'notice-bar' %}
     {%- section 'main-navbar' %}
 
-    {{ content_for_layout }}
+    <main class="main-content">
+      {{ content_for_layout }}
+    </main>
 
     {% section 'main-footer' %}
     {%- render 'cart-drawer' -%}

--- a/sections/main-cart.liquid
+++ b/sections/main-cart.liquid
@@ -135,7 +135,7 @@
       </div>
     </div>
   {%- endif %}
-  <div class='{% if cart and cart.items %}hidden {% endif %} container empty-cart pt-12' id="stick-footer">
+  <div class='{% if cart and cart.items %}hidden {% endif %} container empty-cart pt-12'>
     <div class='flex flex-col justify-center text-center items-center gap-3'>
       <ion-icon
         name='cart-outline'

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -20,7 +20,7 @@
 {%- assign products_per_page = section.settings.products_per_page -%}
 
 {%- paginate search.products by products_per_page cod %}
-  <div class='yc-featured-products yc-search-{{id}} container' id="stick-footer">
+  <div class='yc-featured-products yc-search-{{id}} container'>
     {%- if items %}
       <div class="sort-container search-page">
         {%- render 'main-sort' -%}

--- a/sections/main-upsell.liquid
+++ b/sections/main-upsell.liquid
@@ -1,6 +1,6 @@
 {{ 'upsell.css' | asset_url | stylesheet_tag }}
 
-<div class="upsell-page" id="stick-footer">
+<div class="upsell-page">
   <div class="upsell-container">
     <div class="upsell-content">
       {{ upsell.description }}

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -22,6 +22,11 @@ body {
   position: relative;
 }
 
+.main-content {
+  display: inline-block;
+  width: 100%;
+}
+
 .yc-btn span,
 .yc-btn,
 html,


### PR DESCRIPTION
## Issue
When the page is empty the footer isn't stick at the bottom of the screen correctly


## QA Steps

-  [ ] `pnpm i`
-  [ ] `pnpm dev`
-  [ ]  check the search page or empty collection page

## Note

Leave empty when you have nothing to say
