### PR TITLE
DARK: Fix the countdown css doesn't apply until we have featured-product section

### DIFF
--- a/snippets/product-preview.liquid
+++ b/snippets/product-preview.liquid
@@ -1,5 +1,4 @@
 {{ 'featured-products.css' | asset_url | stylesheet_tag }}
-{{ 'countdown.css' | asset_url | stylesheet_tag }}
 
 <a href="{{ item.url }}">
   <div class='product-thumbnail'>

--- a/snippets/product-slider.liquid
+++ b/snippets/product-slider.liquid
@@ -1,4 +1,5 @@
 {{ 'product-slider.css' | asset_url | stylesheet_tag }}
+{{ 'countdown.css' | asset_url | stylesheet_tag }}
 
 {% style %}
   #yc_slider_{{ id }} .splide__arrow {


### PR DESCRIPTION
## QA Steps

-  [ ] `pnpm i`
-  [ ] `pnpm dev`

## Note

[Thread link](https://youcan-shop.slack.com/archives/C04CW1478R1/p1700210579096199)