### PR TITLE
DARK: Fix the cart drawer not opening

### DIFF
--- a/sections/featured-product-slider.liquid
+++ b/sections/featured-product-slider.liquid
@@ -359,5 +359,3 @@
   ]
 }
 {%- endschema -%}
-
-{{ 'add-to-cart.js' | asset_url | script_tag_deferred }}

--- a/sections/featured-products.liquid
+++ b/sections/featured-products.liquid
@@ -204,5 +204,3 @@
   ]
 }
 {%- endschema -%}
-
-{{ 'add-to-cart.js' | asset_url | script_tag_deferred }}


### PR DESCRIPTION
## QA Steps

 Fix the cart drawer not opening when we don't include the featured-product or product-slider sections

-  [ ] `pnpm i`
-  [ ] `pnpm dev`

## Note
 - we already render the cart-drawer on the theme.liquid
 - [example store](https://jamalmoutajadid.youcan.store/)