### PR TITLE
DARK: fix subcategories not displayed

### DIFF
--- a/sections/main-collection.liquid
+++ b/sections/main-collection.liquid
@@ -5,7 +5,7 @@
 
 <div class='yc-product-listing-container container'>
   {%- paginate collection.products by per_page cod, category_id: category.id %}
-    {%- if items %}
+    {% if items or subCategories.size > 0 %}
       <div class="header-wrapper">
         <div class="head">
           {%- render 'breadcrumbs' -%}


### PR DESCRIPTION
## Note

Fix the issue of the subcategories not displayed when the parent category has no products
