### PR TITLE
DARK: fix the slider has always minus one image 

### DIFF
--- a/snippets/single-product.liquid
+++ b/snippets/single-product.liquid
@@ -86,6 +86,7 @@
     const desktopSlider = new Splide(`#yc_slider_{{ uniqID }}.yc-slider__desktop`, {
       arrows: products > 3,
       rewind: true,
+      focus: 'right',
       perPage: Math.min(products, 4),
       perMove: 1,
       drag: 'free',


### PR DESCRIPTION
[Thread link](https://youcan-shop.slack.com/archives/C04CW1478R1/p1703152861978139)

## QA Steps
-  [ ] go to product slider and add more than 4 images
-  [ ]  the verify on the new themes product page that all the images are displayed

## Note

Leave empty when you have nothing to say
