### PR TITLE
DARK: Single page accordion do not open

### DIFF
--- a/assets/accordion.js
+++ b/assets/accordion.js
@@ -1,24 +1,27 @@
+function accordionClickHandler() {
+  this.classList.toggle("active");
+  const accordionContent = this.nextElementSibling;
+
+  if (accordionContent.style.maxHeight) {
+    /**
+    * If the accordion is currently open, then close it
+    */
+    accordionContent.style.maxHeight = null;
+  } else {
+    /**
+    * If the accordion is currently closed, then open it
+    */
+    accordionContent.style.maxHeight = accordionContent.scrollHeight + "px";
+  }
+}
+
 function setupAccordion() {
   const accordionHeaders = document.querySelectorAll(".accordion-header");
 
   accordionHeaders.forEach((accordion) => {
-    accordion.addEventListener("click", function () {
-      this.classList.toggle("active");
-      
-      const accordionContent = this.nextElementSibling;
-      
-      if (accordionContent.style.maxHeight) {
-        /**
-         * If the accordion is currently open, then close it
-        */
-        accordionContent.style.maxHeight = null;
-      } else {
-        /**
-         * If the accordion is currently closed, then open it
-        */
-        accordionContent.style.maxHeight = accordionContent.scrollHeight + "px";
-      }
-    });
+    // remove the event listener before adding it to prevent duplicates
+    accordion.removeEventListener("click", accordionClickHandler);
+    accordion.addEventListener("click", accordionClickHandler);
   });
 }
 


### PR DESCRIPTION
## Issue
https://youcan-shop.slack.com/archives/C04BDG9HEB1/p1711404546367789

## How to get this issue in your theme?
Make sure that you have just 2 accordions and not 3 in your Single page section

## Why does it happen?
<img width="1426" alt="Screenshot 2024-04-01 at 12 52 51" src="https://github.com/youcan-shop/cod-theme-2/assets/93322743/47fb75a0-deec-43b7-8b51-1eb522424c55">

As we see In this image we have multiple event listeners attached to it causing the accordion to malfunction.

## QA Steps

-  [ ] `pnpm i`
-  [ ] `pnpm run dev`
-  [ ] Go to product page > Single page section
-  [ ] Add 2 accordions
-  [ ] Finally, test the functionality & check the dev-tools section